### PR TITLE
Parameters in kicker command

### DIFF
--- a/cmd/kickbot/main.go
+++ b/cmd/kickbot/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// Game Manager
-	gameMgr := NewGameManager(slack.New(token), DEFAULT_GAMEREQ_TIMEOUT)
+	gameMgr := NewGameManager(slack.New(token))
 	// Routes
 	r := chi.NewRouter()
 


### PR DESCRIPTION
Use parameters in "kicker" command, ditching "/kicker1v1" command

possible flags:
-t(imeout) signed sequence of decimal numbers, each with optional fraction and a unit suffix
- "-t 300ms", "-t 1.5h" or " -t 2h45m".
- Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"

-d(uel)
- starts 2 player duel, if omitted starts 4 player 2vs2